### PR TITLE
[추가] 터렛 선택 시 유지비 및 대미지 표시, 식량이 없을 때 디버프 추가

### DIFF
--- a/Assets/Lomenu UI/Materials/Dissolve/Hexart_DECG.mat
+++ b/Assets/Lomenu UI/Materials/Dissolve/Hexart_DECG.mat
@@ -81,7 +81,7 @@ Material:
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
-    - _Progress: -0.0011015041
+    - _Progress: -0.002379418
     - _RangeIn: 0.034
     - _RangeOut: 0.001
     - _SmoothnessTextureChannel: 0

--- a/Assets/Scenes/InGame.unity
+++ b/Assets/Scenes/InGame.unity
@@ -7583,6 +7583,7 @@ MonoBehaviour:
   hpText: {fileID: 1183078788406832961}
   goldText: {fileID: 1183078788979769994}
   foodText: {fileID: 1395890009}
+  foodImage: {fileID: 83585397}
   memText: {fileID: 1772453970}
   actList:
   - {fileID: 1183078789254342768}
@@ -12831,7 +12832,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2006621125}
   m_HandleRect: {fileID: 2006621124}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:

--- a/Assets/Scripts/Manager/GameMng.cs
+++ b/Assets/Scripts/Manager/GameMng.cs
@@ -70,7 +70,6 @@ public class GameMng : MonoBehaviour
     public bool myTurn = false;                     // 내 차례인지
     public int countHungry = 0;                     // 몇턴이나 굶었는지
 
-
     /**********
      * 게임 서브 매니저
      */
@@ -118,6 +117,8 @@ public class GameMng : MonoBehaviour
     UnityEngine.UI.Text goldText;               // 골드
     [SerializeField]
     UnityEngine.UI.Text foodText;               // 식량
+    [SerializeField]
+    UnityEngine.UI.Image foodImage;             // 식량 이미지
     [SerializeField]
     UnityEngine.UI.Text memText;                // 인원
     [SerializeField]
@@ -415,7 +416,11 @@ public class GameMng : MonoBehaviour
 
         // 유지비가 - 가 되었다면 디버프 행동 추가
         if (_food < 0)
+        {
             countHungry++;
+            if (_food > 0)
+                countHungry = 0;
+        }
 
         if (RandomCount == 0)
         {
@@ -589,6 +594,7 @@ public class GameMng : MonoBehaviour
 
             damageText.text = tile._unitObj._damage.ToString();
             maintCostText.text = tile._unitObj.maintenanceCost.ToString();
+            logoImage[2].sprite = foodImage.sprite;
         }
         else
         {

--- a/Assets/Scripts/Unit/Unit.cs
+++ b/Assets/Scripts/Unit/Unit.cs
@@ -50,23 +50,27 @@ public class Unit : DynamicObject
     {
         GameMng.I.minFood(maintenanceCost);
 
-        if (GameMng.I.countHungry > (NetworkMng.getInstance.v_user.Count * 3))
+        if (GameMng.I.countHungry > (NetworkMng.getInstance.v_user.Count * 9))
         {
-            // Çàµ¿ ºÒ´É
-            _bActAccess = false;
-        }
-        else if (GameMng.I.countHungry > 10)
-        {
-
+            int percent = Random.Range(1, 100);
+            if (percent > 90)
+            {
+                DestroyMyself();
+            }
         }
         else if (GameMng.I.countHungry > (NetworkMng.getInstance.v_user.Count * 6))
         {
-            // ·£´ý »ç¸Á (È®·ü %)
-            int diePercent = Random.Range(1, 100);
-            if (diePercent > 90)
+            // ·£´ý Çàµ¿ºÒ´É (È®·ü %)
+            int percent = Random.Range(1, 100);
+            if (percent > 80)
             {
-                // »ç¸Á
+                _bActAccess = false;
             }
+        }
+        else if (GameMng.I.countHungry > (NetworkMng.getInstance.v_user.Count * 3))
+        {
+            // Ã¼·Â °¨¼Ò
+            _hp -= 1;
         }
     }
 


### PR DESCRIPTION
* 터렛을 클릭하면 메인 UI에 터렛 유지비 및 대미지 표시
* 식량이 없을 때(0 미만일 때) 디버프 추가
    - 필드에 있는 유닛들의 체력이 턴 당 1씩 깎임
    - 디버프가 더 유지되면 유닛이 일정 확률로 행동불능에 걸림
    - 디버프가 계속 유지되면 유닛이 일정 확률로 사망함